### PR TITLE
Fix demo deployment dual-database setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,7 @@ jobs:
             echo 'REPO_NAME=${{ env.REPO_NAME }}' >> ~/deploy/.env
             echo 'IMAGE_TAG=${{ env.IMAGE_TAG }}' >> ~/deploy/.env
             echo 'BACKEND_URL=${{ env.BACKEND_URL }}' >> ~/deploy/.env
+            echo 'SAMPLE_DB_PASSWORD=postgres' >> ~/deploy/.env
 
       - name: Deploy application
         uses: google-github-actions/ssh-compute@v0

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,117 +1,42 @@
-# Trove Demo Environment Deployment
+# Trove Demo Deployment
 
-This directory contains the configuration and scripts for deploying Trove to a demo environment using Docker and Google Cloud Platform.
+Deploy Trove to GCP using Docker Compose.
 
-## Prerequisites
+## Setup
 
-1. A GCP project with the following APIs enabled:
-   - Compute Engine
-   - Container Registry
-
-2. A GCP service account with the following roles:
-   - Storage Admin
-   - Compute Instance Admin
-   - IAP-secured Tunnel User
-
-3. A domain name pointed to your GCP instance's IP address (optional for demo)
-
-## Directory Structure
-
-```
-deploy/
-├── docker-compose.yml    # Production Docker Compose configuration
-├── Caddyfile            # Caddy reverse proxy configuration
-├── deploy.sh            # Main deployment script
-├── Makefile             # Deployment commands
-└── env.example          # Example environment variables
-```
-
-## Initial Setup
-
-1. Copy the example environment file:
-   ```bash
-   cp env.example .env
-   ```
-
-2. Edit `.env` with your configuration:
-   ```bash
-   # Required
-   DOMAIN=your-domain.com
-   EMAIL=your-email@example.com
-   DB_PASSWORD=secure_password_here
-   GCP_PROJECT_ID=your-project-id
-   ```
-
-## Deployment
-
-The deployment process is handled by GitHub Actions, which will:
-1. Build Docker images
-2. Push to Google Container Registry
-3. Deploy to the demo environment
-
-### Manual Deployment
-
-If needed, you can deploy manually:
-
-1. Pull the latest images:
-   ```bash
-   docker compose pull
-   ```
-
-2. Start the stack:
-   ```bash
-   docker compose up -d
-   ```
-
-3. Check the status:
-   ```bash
-   docker compose ps
-   ```
-
-### Health Checks
-
-Monitor service health:
 ```bash
-# Check all services
-docker compose ps
-
-# View logs
-docker compose logs -f [service]
-
-# Check Caddy configuration
-docker compose exec caddy caddy validate
+cp env.example .env
+# Edit .env with your GCP project details
 ```
 
-### Database
+## Local Testing
 
-The database is ephemeral and recreated on each deployment. Important notes:
-- Data is not persisted between deployments
-- Use for demo purposes only
-- For persistent data, modify the volume configuration in docker-compose.yml
+```bash
+make test-deploy  # Access at http://localhost
+```
 
-### Troubleshooting
+## Production Deployment
 
-1. Container Issues:
-   ```bash
-   # Check container logs
-   docker compose logs [service]
+GitHub Actions handles deployment automatically on push to main.
 
-   # Restart a service
-   docker compose restart [service]
-   ```
+### Manual Deploy
 
-2. Caddy Issues:
-   ```bash
-   # Test configuration
-   docker compose exec caddy caddy validate
+On the production server:
 
-   # Reload configuration
-   docker compose exec caddy caddy reload
-   ```
+```bash
+docker compose pull
+docker compose up -d
+```
 
-## Security Notes
+## Database
 
-1. Never commit `.env` files
-2. Keep service account keys secure
-3. Regularly rotate the database password
-4. Monitor container logs for suspicious activity 
+Two databases:
+- `trove-db`: Metadata
+- `sample-db`: Demo data (dbt)
+
+## Troubleshooting
+
+```bash
+docker compose ps          # Check status
+docker compose logs [svc]  # View logs
+```

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -129,7 +129,7 @@ health_check() {
         
         # Check if all containers are running
         local running_containers=$(docker-compose -f "$COMPOSE_FILE" ps -q | wc -l)
-        local expected_containers=4  # frontend, backend, db, caddy
+        local expected_containers=5  # frontend, backend, trove-db, sample-db, caddy
         
         if [[ $running_containers -eq $expected_containers ]]; then
             # Check if services are responding

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -1,0 +1,9 @@
+# Local testing override - uses locally built images
+version: "3.8"
+
+services:
+  backend:
+    image: trove-backend:local
+
+  frontend:
+    image: trove-frontend:local

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -18,16 +18,34 @@ services:
     networks:
       - trove-network
 
-  sample_db:
+  db:
     image: postgres:15-alpine
     container_name: trove-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: trove
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - trove_db_data:/var/lib/postgresql/data
+    networks:
+      - trove-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  sample_db:
+    image: postgres:15-alpine
+    container_name: sample-db
     restart: unless-stopped
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - sample_db_data:/var/lib/postgresql/data
     networks:
       - trove-network
     healthcheck:
@@ -41,10 +59,13 @@ services:
     container_name: trove-backend
     restart: unless-stopped
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@trove-db:5432/postgres
+      DATABASE_URL: postgresql://postgres:postgres@trove-db:5432/trove
       NODE_ENV: production
     depends_on:
-      - sample_db
+      db:
+        condition: service_healthy
+      sample_db:
+        condition: service_healthy
     networks:
       - trove-network
     healthcheck:
@@ -74,7 +95,8 @@ services:
     volumes:
       - ./sample_db/dbt_project:/app
     depends_on:
-      - sample_db
+      sample_db:
+        condition: service_healthy
     networks:
       - trove-network
     environment:
@@ -83,7 +105,8 @@ services:
     command: ["build", "--profiles-dir", "/app/profiles"]
 
 volumes:
-  postgres_data:
+  trove_db_data:
+  sample_db_data:
   caddy_data:
   caddy_config:
 

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -4,6 +4,7 @@ EMAIL=admin@trove.dev
 
 # Database Configuration
 DB_PASSWORD=your_secure_database_password_here
+SAMPLE_DB_PASSWORD=postgres
 
 # Google Cloud Platform Configuration
 GCP_PROJECT_ID=your-gcp-project-id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,30 @@
 version: "3.8"
 
 services:
+  db:
+    image: postgres:15-alpine
+    container_name: trove-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: trove
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - trove_db_data:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+    networks:
+      - trove-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 10s
+      retries: 3
+
   sample_db:
     image: postgres:15-alpine
     container_name: sample-db
+    restart: unless-stopped
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
@@ -13,12 +34,53 @@ services:
     ports:
       - "5432:5432"
     networks:
-      - trove-net
+      - trove-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
-      timeout: 5s
-      retries: 5
+      timeout: 10s
+      retries: 3
+
+  backend:
+    build: ./backend
+    restart: unless-stopped
+    env_file:
+      - ./backend/.env
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@trove-db:5432/trove
+    volumes:
+      - ./backend:/app # Mount BE code for hot reloading
+    depends_on:
+      db:
+        condition: service_healthy
+      sample_db:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    networks:
+      - trove-network
+
+  frontend:
+    build:
+      context: ./frontend
+      # dockerfile: prod.Dockerfile # Production
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    volumes:
+      - ./frontend:/app # Mount frontend code for hot reloading (DEV only)
+      - /app/node_modules
+    depends_on:
+      - backend
+    networks:
+      - trove-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    env_file:
+      - ./frontend/.env
 
   dbt:
     build: ./sample_db
@@ -28,72 +90,14 @@ services:
       sample_db:
         condition: service_healthy
     networks:
-      - trove-net
+      - trove-network
     environment:
       DBT_PROFILES_DIR: /app/profiles
 
-  db:
-    image: postgres:15-alpine
-    container_name: trove-db
-    environment:
-      POSTGRES_DB: trove
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - db_data:/var/lib/postgresql/data
-    ports:
-      - "5433:5432"
-    networks:
-      - trove-net
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
-  backend:
-    build: ./backend
-    env_file:
-      - ./backend/.env
-    environment:
-      - DATABASE_URL=postgresql://postgres:postgres@trove-db:5432/trove
-    volumes:
-      - ./backend:/app # Mount BE code for hot reloading
-    depends_on:
-      sample_db:
-        condition: service_healthy
-      db:
-        condition: service_healthy
-    ports:
-      - "8000:8000"
-    networks:
-      - trove-net
-
-  frontend:
-    build:
-      context: ./frontend
-      # dockerfile: prod.Dockerfile # Production
-    ports:
-      - "3001:3000"
-    volumes:
-      - ./frontend:/app # Mount frontend code for hot reloading (DEV only)
-      - /app/node_modules
-    depends_on:
-      - backend
-    networks:
-      - trove-net
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3001"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    env_file:
-      - ./frontend/.env
-
 volumes:
+  trove_db_data:
   sample_db_data:
-  db_data:
 
 networks:
-  trove-net:
+  trove-network:
     driver: bridge

--- a/sample_db/dbt_project/profiles/profiles.yml
+++ b/sample_db/dbt_project/profiles/profiles.yml
@@ -3,7 +3,7 @@ test_profile:
   outputs:
     dev:
       type: postgres
-      host: sample_db
+      host: sample-db
       user: postgres
       password: postgres
       port: 5432


### PR DESCRIPTION
## Summary
  Fixes demo deployment to use dual-database architecture matching dev environment.

  ## Problem
  - Demo had only one database, causing migrations and dbt to fail
  - Backend tried to connect to wrong database name
  - dbt couldn't connect to sample database

  ## Solution
  - Added `sample-db` database for demo data (dbt)
  - Added `trove-db` database for metadata (migrations)
  - Fixed backend DATABASE_URL to use `trove` database
  - Fixed dbt hostname to `sample-db`
  - Standardized naming between dev and deploy environments

  ## Changes
  - `deploy/docker-compose.yml`: Added dual-database setup
  - `deploy/deploy.sh`: Updated container count to 5
  - `sample_db/dbt_project/profiles/profiles.yml`: Fixed hostname
  - `docker-compose.yml`: Standardized naming (network, volumes, restart policies)
  - `Makefile`: Added `make test-deploy` target

  ## Testing
  ```bash
  make test-deploy

  Should see:
  - 5 containers running
  - Backend migrations complete on trove-db
  - dbt data seeded on sample-db
  - Frontend at http://localhost